### PR TITLE
Add a My link for the HACS integration install

### DIFF
--- a/docs/integration/installation.md
+++ b/docs/integration/installation.md
@@ -10,6 +10,8 @@ The easiest way to do this (and to add tons of other useful integrations) is by 
 
 You can also ask for help in the HA forums if you're stuck.
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=LAB02-Research&repository=HASS.Agent-Integration)
+
 When you've installed HACS (and restarted HA), just open it by clicking on it on the toolbar on the leftside of HA. Then click `Integrations` -> `EXPLORE & DOWNLOAD REPOSITORIES` (bottom right) and search for `HASS.Agent`.
 
 > Note: you ONLY need the `HASS.Agent` integration. The `notification` and `media_player` integrations are legacy, you can ignore them.


### PR DESCRIPTION
Added a My Home Assistant link for the HACS integration install

https://hacs.xyz/docs/basic/my

It probably needs to be rewritten a bit