### PR TITLE
Incorrect quotes used

### DIFF
--- a/docs/wmi-examples.md
+++ b/docs/wmi-examples.md
@@ -44,9 +44,9 @@ Query: ```SELECT Value FROM AIDA64_SensorValues WHERE ID="TGPU1"```
 
 Query: ```SELECT DeviceID FROM Win32_USBHub WHERE DeviceID LIKE "USB\\VID_19F7&PID_0003%"```
 
-#### Check for multiple active procsses
+#### Check for multiple active processes
 
-Query: ```Select * from Win32_Process Where Name = ‘bf2042.exe’ OR Name = ‘HorizonZeroDawn.exe’ OR Name = ‘HaloInfinite.exe’ OR Name = ‘Cyberpunk2077.exe’ OR Name = ‘BlackOpsColdWar.exe’ OR Name = ‘ModernWarfare.exe’ OR Name = ‘GoW.exe’ OR Name = ‘reactivedrop.exe’```
+Query: ```Select * from Win32_Process Where Name = 'bf2042.exe' OR Name = 'HorizonZeroDawn.exe' OR Name = 'HaloInfinite.exe' OR Name = 'Cyberpunk2077.exe' OR Name = 'BlackOpsColdWar.exe' OR Name = 'ModernWarfare.exe' OR Name = 'GoW.exe' OR Name = 'reactivedrop.exe'```
 
 Thanks **stephack**
 


### PR DESCRIPTION
I see incorrect quotes were used therefor the WMI query for "Check for multiple active processes" was not working.