### PR TITLE
Fix typo mac adress and use new service

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -74,7 +74,7 @@ tts_test:
 ```yaml
 - platform: wake_on_lan
   name: "your_pc_name"
-  mac: "00-00-00-00-00-00"
+  mac: "00:01:02:03:04:05"
   host: 10.0.0.5
   broadcast_address: 10.0.0.255
   turn_off:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -78,9 +78,9 @@ tts_test:
   host: 10.0.0.5
   broadcast_address: 10.0.0.255
   turn_off:
-    service: switch.turn_on
+    service: button.press
     data:
-      entity_id: switch.your_pc_hass_agent_shutdown_switch
+      entity_id: button.your_pc_hass_agent_shutdown
 ```
 
 Alternative version: use a `Hibernate Command` to put your PC in hibernation instead.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ Example configuration of a shutdown command in Home Assistant, used in combinati
 ```yaml
 - platform: wake_on_lan
   name: "TEST_W10_x64_01"
-  mac: "00:00:00:00:00:00"
+  mac: "00:01:02:03:04:05"
   host: 10.0.0.5
   broadcast_address: 10.0.0.255
   turn_off:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ Example configuration of a shutdown command in Home Assistant, used in combinati
 ```yaml
 - platform: wake_on_lan
   name: "TEST_W10_x64_01"
-  mac: "00-00-00-00-00-00"
+  mac: "00:00:00:00:00:00"
   host: 10.0.0.5
   broadcast_address: 10.0.0.255
   turn_off:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,9 +42,9 @@ Example configuration of a shutdown command in Home Assistant, used in combinati
   host: 10.0.0.5
   broadcast_address: 10.0.0.255
   turn_off:
-    service: switch.turn_on
+    service: button.press
     data:
-      entity_id: switch.test_w10_x64_01_cmd_shutdown
+      entity_id: button.test_w10_x64_01_cmd_shutdown
 ```
 
 


### PR DESCRIPTION
Fix the typo of the mac adress https://www.home-assistant.io/integrations/wake_on_lan/#mac
and using the service press button